### PR TITLE
fix: handle detect-gpu FALLBACK type for ad-blocker resilient 3D dete…

### DIFF
--- a/src/hooks/useRandomMovie.ts
+++ b/src/hooks/useRandomMovie.ts
@@ -1,7 +1,7 @@
-// Discovery hook with filter relaxation and taste scoring
+// Discovery hook with filter relaxation, taste scoring, and provider verification
 
 import { useCallback } from "react";
-import { discoverMovie } from "@/services/tmdb/discover";
+import { discoverCandidates } from "@/services/tmdb/discover";
 import { fetchMovieDetails } from "@/services/tmdb/details";
 import { useMovieHistoryStore } from "@/stores/movieHistoryStore";
 import { useDiscoveryStore } from "@/stores/discoveryStore";
@@ -9,6 +9,33 @@ import { usePreferencesStore } from "@/stores/preferencesStore";
 import { useRegionStore } from "@/stores/regionStore";
 import { scoreTasteMatch } from "@/lib/taste-engine";
 import { getGenreName } from "@/lib/genre-map";
+import type { TMDBMovieDetails } from "@/types/movie";
+
+/**
+ * Safety-net: verify the user's services appear in streaming tiers
+ * (flatrate/free/ads) for the given region. TMDB discover is ~100%
+ * consistent with per-movie data when using flatrate monetization,
+ * so this should almost always pass on the first candidate.
+ */
+function verifyProviderMatch(
+  details: TMDBMovieDetails,
+  userServiceIds: number[],
+  region: string,
+): boolean {
+  if (userServiceIds.length === 0) return true;
+
+  const regionData = details["watch/providers"]?.results?.[region];
+  if (!regionData) return false;
+
+  const userSet = new Set(userServiceIds);
+  const streamingTiers = [regionData.flatrate, regionData.free, regionData.ads];
+
+  for (const tier of streamingTiers) {
+    if (tier?.some((p) => userSet.has(p.provider_id))) return true;
+  }
+
+  return false;
+}
 
 export function useRandomMovie() {
   const currentMovie = useDiscoveryStore((s) => s.currentMovie);
@@ -22,62 +49,93 @@ export function useRandomMovie() {
     const regionState = useRegionStore.getState();
     const prefsState = usePreferencesStore.getState();
 
-    const excludeIds = historyState.getExcludeSet();
     const filters = discoveryState.filters;
     const region = regionState.effectiveRegion();
 
+    // Capture prev movie so we can guarantee it's excluded
+    const prevMovieId = discoveryState.currentMovie?.id ?? null;
+
+    // Clear old movie so loading state is visible and errors aren't hidden
+    // behind a stale movie. DiscoveryPage shows LoadingQuotes when isLoading.
+    discoveryState.setCurrentMovie(null);
     discoveryState.setLoading(true);
     discoveryState.setError(null);
+
+    // Build exclude set: history + current movie (belt-and-suspenders)
+    const excludeIds = new Set(historyState.getExcludeSet());
+    if (prevMovieId) excludeIds.add(prevMovieId);
 
     // Lock provider/genre filters when user has explicitly set them via onboarding/settings
     const hasUserFilters =
       prefsState.hasCompletedOnboarding &&
-      (prefsState.preferredProvider !== null ||
+      (prefsState.myServices.length > 0 ||
+        prefsState.preferredProvider !== null ||
         prefsState.preferredGenre !== null);
 
+    // User's selected streaming service IDs for provider verification
+    const userServiceIds =
+      prefsState.myServices.length > 0
+        ? prefsState.myServices
+        : prefsState.preferredProvider
+          ? [Number(prefsState.preferredProvider)]
+          : [];
+
     try {
-      const result = await discoverMovie(
-        {
-          ...filters,
-          region,
-        },
+      const result = await discoverCandidates(
+        { ...filters, region },
         excludeIds,
-        0,
         { lockUserFilters: hasUserFilters },
       );
 
-      if (result.movie) {
-        // Fetch full details for the discovered movie
-        const details = await fetchMovieDetails(result.movie.id);
+      if (result.candidates.length > 0) {
+        // Verify candidates against user's streaming services.
+        // With flatrate-only discover, this is ~100% consistent —
+        // the loop is a safety net for rare TMDB data lag.
+        let verifiedDetails: TMDBMovieDetails | null = null;
+        let firstDetails: TMDBMovieDetails | null = null;
+
+        for (const candidate of result.candidates) {
+          const details = await fetchMovieDetails(candidate.id);
+          if (!firstDetails) firstDetails = details;
+
+          if (verifyProviderMatch(details, userServiceIds, region)) {
+            verifiedDetails = details;
+            break;
+          }
+        }
+
+        // Use verified match, or fall back to first candidate (best effort)
+        const chosen = verifiedDetails ?? firstDetails!;
 
         // Apply taste scoring (informational — log for now, sorting in Phase 3)
-        const tasteScore = scoreTasteMatch(prefsState.tasteProfile, details);
+        const tasteScore = scoreTasteMatch(prefsState.tasteProfile, chosen);
         if (tasteScore !== 0) {
           console.debug(
-            `[taste] Movie "${details.title}" scored ${tasteScore.toFixed(2)}`,
+            `[taste] Movie "${chosen.title}" scored ${tasteScore.toFixed(2)}`,
           );
         }
 
         // Track as shown to prevent repeats
-        historyState.trackShown(result.movie.id);
+        historyState.trackShown(chosen.id);
 
         // Update discovery store with full details
-        discoveryState.setCurrentMovie(details);
+        discoveryState.setCurrentMovie(chosen);
         discoveryState.setRelaxationStep(result.relaxationStep);
       } else {
         // Build a descriptive error so the user knows what to change
         const genreLabel = filters.genreId
           ? getGenreName(Number(filters.genreId))
           : null;
-        const hasProvider = filters.providerId !== null;
+        const hasProviders = filters.providerIds.length > 0;
 
         let msg: string;
-        if (genreLabel && hasProvider) {
-          msg = `No ${genreLabel} movies available on this streaming service in your region.`;
+        if (genreLabel && hasProviders) {
+          msg = `No ${genreLabel} movies available on these streaming services in your region.`;
         } else if (genreLabel) {
           msg = `No ${genreLabel} movies available for streaming in your region.`;
-        } else if (hasProvider) {
-          msg = "No movies available on this streaming service in your region.";
+        } else if (hasProviders) {
+          msg =
+            "No movies available on these streaming services in your region.";
         } else {
           msg = "No movies found matching your filters.";
         }

--- a/src/stores/discoveryStore.ts
+++ b/src/stores/discoveryStore.ts
@@ -3,7 +3,7 @@ import type { TMDBMovieDetails } from "@/types/movie";
 
 interface DiscoveryFilters {
   genreId: string | null;
-  providerId: number | null;
+  providerIds: number[];
   minRating: number;
   minVoteCount: number;
 }
@@ -25,7 +25,7 @@ interface DiscoveryState {
 
 const DEFAULT_FILTERS: DiscoveryFilters = {
   genreId: null,
-  providerId: null,
+  providerIds: [],
   minRating: 6.0,
   minVoteCount: 500,
 };


### PR DESCRIPTION
…ction

detect-gpu resolves (not throws) with type:'FALLBACK' when benchmarks are blocked by ad blockers. Previous fix only caught thrown errors which never occurred. Now checks gpuTier.type and uses local WebGL renderer heuristic to classify GPU tier when benchmarks are unavailable.