### PR TITLE
fix(browse): stabilize sidebar close behavior and improve testability

### DIFF
--- a/src/components/browse/BrowseBentoHero.tsx
+++ b/src/components/browse/BrowseBentoHero.tsx
@@ -83,7 +83,10 @@ export function BrowseBentoHero({
 
               {/* Title + subtitle */}
               <div>
-                <h1 className="text-clay-text font-heading font-bold text-xl leading-tight">
+                <h1
+                  data-testid="browse-heading"
+                  className="text-clay-text font-heading font-bold text-xl leading-tight"
+                >
                   Browse
                 </h1>
                 {providerName ? (

--- a/src/components/browse/BrowseFilterSidebar.tsx
+++ b/src/components/browse/BrowseFilterSidebar.tsx
@@ -66,14 +66,17 @@ export function BrowseFilterSidebar({
     }
   }, [open]);
 
-  // Close on Escape key
+  // Close on Escape key — capture phase ensures we fire before dropdowns
   useEffect(() => {
     if (!open) return;
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
     }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [open, onClose]);
 
   const handleGenreToggle = useCallback(
@@ -98,6 +101,7 @@ export function BrowseFilterSidebar({
           {/* Backdrop */}
           <motion.div
             key="filter-backdrop"
+            data-testid="filter-backdrop"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}

--- a/src/pages/BrowsePage.tsx
+++ b/src/pages/BrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { SlidersHorizontal, AlertCircle, Tv } from "lucide-react";
 import { motion } from "motion/react";
 import { useBrowseStore } from "@/stores/browseStore";
@@ -57,6 +57,8 @@ export default function BrowsePage() {
   const selectedProviderName =
     regionProviders.find((p) => p.provider_id === selectedProviderId)
       ?.provider_name ?? null;
+
+  const handleFilterClose = useCallback(() => setFilterOpen(false), []);
 
   const filtersActive = hasNonDefaultFilters(filters);
 
@@ -209,10 +211,7 @@ export default function BrowsePage() {
       )}
 
       {/* Filter sidebar */}
-      <BrowseFilterSidebar
-        open={filterOpen}
-        onClose={() => setFilterOpen(false)}
-      />
+      <BrowseFilterSidebar open={filterOpen} onClose={handleFilterClose} />
     </div>
   );
 }


### PR DESCRIPTION
- Use capture-phase Escape listener with stopPropagation to prevent MetalDropdown from intercepting the key event
- Stabilize onClose callback with useCallback to prevent useEffect re-registration on every render
- Add data-testid to BentoHero heading and filter backdrop for reliable Playwright targeting